### PR TITLE
Revert "fixed the bug where the server wouldn't die when project wasn't opened"

### DIFF
--- a/src/server/api/v3/file.js
+++ b/src/server/api/v3/file.js
@@ -15,18 +15,14 @@ function init(path, machinetool){
 	this.apt = new StepNC.AptStepMaker();
 	this.tol = new StepNC.Tolerance();
 	this.ms = new StepNC.machineState(path);
-	if(!this.ms)
-		process.exit();
 	if(machinetool !== ""){
 		if(!this.ms.LoadMachine(machinetool))
 			console.log("ERROR: Machinetool was not loaded");
 		else
 			console.log("Loaded Machine Successfully")
 	}
-	if(!this.find.OpenProject(path))
-		process.exit();
-	if(!this.apt.OpenProject(path))
-		process.exit();
+	this.find.OpenProject(path);
+	this.apt.OpenProject(path);
 	return;
 }
 


### PR DESCRIPTION
closes the server when it has a bad model but also a good one
