### PR TITLE
Fixed issue with part/toolpath geometry not moving with fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bugfixes:
 - Fixed problem with locking view not rendering immediately
 - Fixed view alignment problems with some models and with machine tools
 - Fixed broken mobile view / responsiveness after adding locked view
+- Part and toolpath geometry move with fixture when needed
 
 Reverted:
 

--- a/src/client/models/nc.js
+++ b/src/client/models/nc.js
@@ -339,7 +339,7 @@ export default class NC extends THREE.EventDispatcher {
                 }
                 let obj = self._objects[geom.id];
                 if(obj !== undefined) {
-                    if (obj.rendered !== false && obj.usage === 'cutter' || obj.usage === 'machine' || obj.usage === 'fixture') {
+                    if (obj.rendered !== false) {
                         let transform = new THREE.Matrix4();
                         if (!geom.xform) return;
                         transform.fromArray(geom.xform);
@@ -347,8 +347,14 @@ export default class NC extends THREE.EventDispatcher {
                         let quaternion = new THREE.Quaternion();
                         let scale = new THREE.Vector3();
                         transform.decompose(position, quaternion, scale);
+                        // we need to update all 3D properties so that
+                        // annotations, overlays and objects are all updated
                         obj.object3D.position.copy(position);
                         obj.object3D.quaternion.copy(quaternion);
+                        obj.annotation3D.position.copy(position);
+                        obj.annotation3D.quaternion.copy(quaternion);
+                        obj.overlay3D.position.copy(position);
+                        obj.overlay3D.quaternion.copy(quaternion);
                         alter = true;
                     }
                 }


### PR DESCRIPTION
This happened on machines with moving tables such as the Okuma
