### PR TITLE
When machine tool is loaded, use zoom to fit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
 - Tolerance View now displays workpieces and all subcomponents of those workpieces as well as tolerances associated with any of these workpieces
 - 404 error page improved 404%!
 - Styling overhaul of the sidebar
+- Keeps entire tool in view when machine is loaded
 
 Bugfixes:
 

--- a/src/client/views/cad/index.jsx
+++ b/src/client/views/cad/index.jsx
@@ -81,9 +81,15 @@ export default class CADView extends React.Component {
         // calculate the scene's radius for draw distance calculations
         this.updateSceneBoundingBox(model.getBoundingBox());
         
-        // set the default view
-        this.alignToolView(this.props.manager.getSelected());
-        this.invalidate();
+        let sel = this.props.manager.getSelected();
+        
+        if (_.find(_.values(sel[0]._objects), {usage: 'machine'})) {
+            this.setState({lockedView: false});
+            // set the default view
+            this.zoomToFit(sel);
+            this.invalidate();
+        }
+
         
         // Update the model tree
         let tree = this.props.manager.getTree();


### PR DESCRIPTION
Instead of the lock-to-tool view
