### PR TITLE
This will make the tolerances pane work everytime

### DIFF
--- a/src/server/api/v3/file.js
+++ b/src/server/api/v3/file.js
@@ -14,8 +14,8 @@ function init(path, machinetool){
 	fs.accessSync(path, fs.R_OK , (err) => {
   		process.exit();
 	});
-	this.find = new StepNC.Finder();
 	this.apt = new StepNC.AptStepMaker();
+	this.find = new StepNC.Finder();
 	this.tol = new StepNC.Tolerance();
 	this.ms = new StepNC.machineState(path);
 	if(machinetool !== ""){
@@ -24,8 +24,8 @@ function init(path, machinetool){
 		else
 			console.log("Loaded Machine Successfully")
 	}
-	this.find.OpenProject(path);
 	this.apt.OpenProject(path);
+	this.find.OpenProject(path);
 	return;
 }
 


### PR DESCRIPTION
This was caused by the ordering of how the aptstepmaker and finder were opened, the aptstepmaker must be created and opened before the respective finder calls
