### PR TITLE
Fixed problem with workpieces not showing up

### DIFF
--- a/src/server/api/v3/file.js
+++ b/src/server/api/v3/file.js
@@ -4,11 +4,6 @@ let fs = require("fs");
 //Query for a json file that maps all projects in the data directory
 //to a particular path in the data folder
 
-let path;
-let find;
-let apt;
-let tol;
-let ms;
 
 function init(path, machinetool){
 	fs.accessSync(path, fs.R_OK , (err) => {
@@ -17,6 +12,10 @@ function init(path, machinetool){
 	this.apt = new StepNC.AptStepMaker();
 	this.find = new StepNC.Finder();
 	this.tol = new StepNC.Tolerance();
+
+	this.apt.OpenProject(path);
+	this.find.OpenProject(path);
+	
 	this.ms = new StepNC.machineState(path);
 	if(machinetool !== ""){
 		if(!this.ms.LoadMachine(machinetool))
@@ -24,13 +23,11 @@ function init(path, machinetool){
 		else
 			console.log("Loaded Machine Successfully")
 	}
-	this.apt.OpenProject(path);
-	this.find.OpenProject(path);
 	return;
 }
 
 module.exports.init = init;
-module.exports.find = find;
-module.exports.apt = apt;
-module.exports.tol = tol;
-module.exports.ms = ms;
+module.exports.find = this.find;
+module.exports.apt = this.apt;
+module.exports.tol = this.tol;
+module.exports.ms = this.ms;


### PR DESCRIPTION
This is some sort of strange workaround to the problem where an empty list of workpieces comes back from the underlying node functionality
