### PR TITLE
Keep preview pane open when switching entities if possible

### DIFF
--- a/src/client/stylesheets/components/_sidebar.scss
+++ b/src/client/stylesheets/components/_sidebar.scss
@@ -249,8 +249,15 @@ $icons: '../icons/';
                 position: absolute;
                 right: 15px;
 
-                &:hover:not(&.button) {
-                    color: #777777;
+                &:not(.button) {
+                    padding: 3px;
+                    color: #F8F8F8;
+                    background-color: #333333;
+                    border-radius: 5px;
+
+                    &:hover {
+                        color: #28AEE9;
+                    }
                 }
             }
 

--- a/src/client/stylesheets/components/_sidebar.scss
+++ b/src/client/stylesheets/components/_sidebar.scss
@@ -244,6 +244,16 @@ $icons: '../icons/';
             align-items: center;
             white-space: normal;
 
+            .preview-icon {
+                font-size: 20px;
+                position: absolute;
+                right: 15px;
+
+                &:hover:not(&.button) {
+                    color: #777777;
+                }
+            }
+
             &:hover:not(.rc-menu-item-disabled) {
                 cursor: pointer;
                 background-color: rgba(#2BAEE9, 0.5);

--- a/src/client/views/geometry/index.jsx
+++ b/src/client/views/geometry/index.jsx
@@ -142,15 +142,31 @@ export default class GeometryView extends React.Component {
       }
     }
 
-    if (this.props.viewType === 'preview' &&
-        nextProps.selectedEntity &&
+    if (this.props.viewType === 'preview') {
+
+      // unhighlight old faces first if we're switching entities
+      if (this.props.selectedEntity &&
+          this.props.selectedEntity.type === 'tolerance' &&
+          this.props.selectedEntity !== nextProps.selectedEntity) {
+        
+        this.highlightFaces(
+          this.props.selectedEntity.faces,
+          this.props.manager.getRootModel(this.props.selectedEntity.workpiece),
+          true
+        );
+      }
+      
+      // then highlight new faces
+      if (nextProps.selectedEntity &&
         nextProps.selectedEntity.type === 'tolerance') {
-      this.highlightFaces(
-        nextProps.selectedEntity.faces,
-        nextProps.manager.getRootModel(nextProps.selectedEntity.workpiece),
-        false,
-        highlightColor
-      );
+
+        this.highlightFaces(
+          nextProps.selectedEntity.faces,
+          nextProps.manager.getRootModel(nextProps.selectedEntity.workpiece),
+          false,
+          highlightColor
+        );
+      }
     }
   }
 

--- a/src/client/views/sidebar/propertiespane/index.jsx
+++ b/src/client/views/sidebar/propertiespane/index.jsx
@@ -133,8 +133,30 @@ export default class PropertiesPane extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.entity !== nextProps.entity ||
-        nextProps.entity === null) {
+    
+    let old_wp, new_wp;
+    
+    if (this.props.entity) {
+      if (this.props.entity.type === 'workpiece') {
+        old_wp = this.props.entity.id;
+      } else if (this.props.entity.type === 'tolerance') {
+        old_wp = this.props.entity.workpiece;
+      } else if (this.props.entity.type === 'workingstep') {
+        old_wp = this.props.entity.toBe.id;
+      }
+    }
+    
+    if (nextProps.entity) {
+      if (nextProps.entity.type === 'workpiece') {
+        new_wp = nextProps.entity.id;
+      } else if (nextProps.entity.type === 'tolerance') {
+        new_wp = nextProps.entity.workpiece;
+      } else if (nextProps.entity.type === 'workingstep') {
+        new_wp = nextProps.entity.toBe.id;
+      }
+    }
+    
+    if (!nextProps.entity || new_wp !== old_wp) {
       this.props.previewCb(false);
     }
   }

--- a/src/client/views/sidebar/propertiespane/index.jsx
+++ b/src/client/views/sidebar/propertiespane/index.jsx
@@ -146,19 +146,17 @@ export default class PropertiesPane extends React.Component {
     return null;
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  componentWillReceiveProps(nextProps) {
     
     let new_wp = this.getWPForEntity(nextProps.entity);
-    let old_wp = this.getWPForEntity(this.props.entity);
     let prev_wp = this.getWPForEntity(this.state.previewEntity);
 
     if (!nextProps.entity ||
         (nextProps.entity !== this.props.entity && new_wp !== prev_wp)) {
-      console.log("closing preview");
-      console.log(nextProps.entity);
-      console.log(new_wp);
-      console.log(prev_wp);
       this.props.previewCb(false);
+    }
+    else if (nextProps.entity !== this.props.entity && new_wp === prev_wp) {
+      this.setState({'previewEntity': nextProps.entity})
     }
   }
 


### PR DESCRIPTION
This addresses #343 and adds a preview button to entity nodes that can be previewed
