### PR TITLE
Recurse down the tree when a workplan is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 1.7.0
+
+Features:
+
+Bugfixes:
+
+- Disabled workplans disable all children, not just immediate
+
 Version 1.6.0
 
 Features:

--- a/src/server/api/v3/step.js
+++ b/src/server/api/v3/step.js
@@ -64,9 +64,7 @@ function exeFromId(id) {
     ws.enabled = true;
   } else {
     ws.enabled = false;
-    _.each(ws.children, (child) => {
-      child.enabled = false;
-    });
+    propagateDisabled(ws);
   }
 
   if (find.IsWorkingstep(id)) {
@@ -86,6 +84,15 @@ function exeFromId(id) {
   }
 
   return ws;
+}
+
+function propagateDisabled(ws) {
+  if (ws.children) {
+    _.each(ws.children, (child) => {
+      child.enabled = ws.enabled;
+      propagateDisabled(child);
+    });
+  }
 }
 
 


### PR DESCRIPTION
Instead of just disabling its immediate children
