### PR TITLE
Properly loads tolerance workingstep info after refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 1.7.1
+
+Features:
+
+Bugfixes:
+
+- Tolerances can be examined in the properties pane again
+
 Version 1.7.0
 
 Features:

--- a/src/client/views/responsive/index.jsx
+++ b/src/client/views/responsive/index.jsx
@@ -178,7 +178,7 @@ export default class ResponsiveView extends React.Component {
           for (let i of json[node.workpiece].workingsteps) {
             let ws = this.state.workingstepCache[i];
             if (node.workpiece === ws.toBe.id) {
-              workingsteps.push(json[node.workpiece].workingsteps[i]);
+              workingsteps.push(i);
             }
           }
           node.workingsteps = workingsteps;


### PR DESCRIPTION
This fixes the bug introduced in v1.7.0
